### PR TITLE
Make About section text responsive

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -314,7 +314,7 @@ input:focus, select:focus, textarea:focus{outline:2px solid var(--accent)}
   font-optical-sizing: auto;
   font-weight: 300;
   font-style: normal;
-  font-size: 20PX;
+  font-size: clamp(1rem, 2vw + 0.5rem, 1.25rem);
 
 }
 


### PR DESCRIPTION
## Summary
- use `clamp()` for `.about-split p` font-size so text scales across screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f09829350832b9e5e9235ccce59b5