### PR TITLE
Close mobile nav after link activation

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -15,6 +15,11 @@ if (navToggle) {
 $$('.site-nav a').forEach(a => {
   const here = location.pathname.split('/').pop() || 'index.html';
   if (a.getAttribute('href') === here) a.classList.add('active');
+
+  a.addEventListener('click', () => {
+    siteNav.classList.remove('open');
+    if (navToggle) navToggle.setAttribute('aria-expanded', 'false');
+  });
 });
 
 // Prefill interest → contact page


### PR DESCRIPTION
## Summary
- collapse mobile navigation when any nav link is activated

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f09834bb4832bbb81d50891bc0fb6