### PR TITLE
Ensure contact image keeps aspect ratio on mobile

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -248,7 +248,7 @@ input:focus, select:focus, textarea:focus{outline:2px solid var(--accent)}
 /* Mobile stacking like your Figma */
 @media (max-width: 800px){
   .contact-wrap{ grid-template-columns:1fr; }
-  .contact-image{ height:260px !important; }  /* fixed when stacked */
+  .contact-image{ height:auto !important; aspect-ratio:16/9; }  /* maintain 16:9 crop when stacked */
 }
 
 .industry-grid {


### PR DESCRIPTION
## Summary
- maintain 16:9 crop for `.contact-image` on narrow screens using `aspect-ratio`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f086954a0832bbc9fe608590584da