### PR TITLE
Make industry cards responsive

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -260,7 +260,7 @@ input:focus, select:focus, textarea:focus{outline:2px solid var(--accent)}
 .industry-card {
   display: flex;
   flex-direction: row;
-  height: 250px; /* make all cards same height */
+  min-height: 250px; /* minimum card height */
   background: white;
   border-radius: 10px;
   overflow: hidden;
@@ -289,7 +289,7 @@ input:focus, select:focus, textarea:focus{outline:2px solid var(--accent)}
 .industry-card {
   display: flex;
   flex-direction: row;
-  height: 250px; /* make all cards same height */
+  min-height: 250px; /* minimum card height */
   background: white;
   border-radius: 10px;
   overflow: hidden;
@@ -307,6 +307,12 @@ input:focus, select:focus, textarea:focus{outline:2px solid var(--accent)}
   display: flex;
   flex-direction: column;
   justify-content: center;
+}
+
+@media (max-width: 800px) {
+  .industry-card {
+    flex-direction: column;
+  }
 }
 
 .about-split p {


### PR DESCRIPTION
## Summary
- Allow industry cards to expand by using a minimum height instead of a fixed height
- Stack industry card images and text vertically on screens narrower than 800px

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f0851a178832ba8d0b36016fafdc9