### PR TITLE
Anchor mobile menu below header

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -61,7 +61,7 @@ img{max-width:100%; height:auto; display:block}
 
 @media (max-width: 800px){
   .nav-toggle{display:block}
-  .site-nav{display:none; flex-direction:column; position:absolute; right:1rem; top:64px; background:var(--bg); padding:1rem; border:1px solid var(--border); border-radius:12px; box-shadow:var(--shadow)}
+  .site-nav{display:none; flex-direction:column; position:absolute; right:1rem; top:100%; background:var(--bg); padding:1rem; border:1px solid var(--border); border-radius:12px; box-shadow:var(--shadow)}
   .site-nav.open{display:flex}
 }
 


### PR DESCRIPTION
## Summary
- ensure mobile navigation drops directly below header by using `top: 100%` in responsive styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f020eb320832bba96aab05db723f9